### PR TITLE
Add tvOS and re-add `lipo` steps to `xcframework` build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
   CARGO_TERM_COLOR: always
-  TOOLCHAIN: stable
+  TOOLCHAIN: nightly
 
 jobs:
   integration_tests:
@@ -15,7 +15,7 @@ jobs:
       - name: Install Rust Nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env.TOOLCHAIN }}
           default: true
       - name: Cache
         uses: actions/cache@v3

--- a/.github/workflows/x86_64-apple-ios.yml
+++ b/.github/workflows/x86_64-apple-ios.yml
@@ -4,7 +4,7 @@ name: x86_64-apple-ios
 on: push
 
 env:
-  TOOLCHAIN: stable
+  TOOLCHAIN: nightly
   CARGO_TERM_COLOR: always
   DYLD_ROOT_PATH: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/
 
@@ -18,7 +18,7 @@ jobs:
       - name: Install Rust Nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env.TOOLCHAIN }}
           target: x86_64-apple-ios
           default: true
       - name: Cache

--- a/.github/workflows/x86_64-linux-android.yml
+++ b/.github/workflows/x86_64-linux-android.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Rust Nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env.TOOLCHAIN }}
           target: x86_64-linux-android
           default: true
       - name: Cache Cargo

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,7 +10,7 @@ CARGO_MAKE_RUST_SCRIPT_PROVIDER = "rust-script"
 CARGO_MAKE_USE_WORKSPACE_PROFILE = true
 CARGO_MAKE_CARGO_BUILD_TEST_FLAGS = "--no-fail-fast"
 CARGO_TARGET_DIR = { value = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target", condition = { env_not_set = ["CARGO_TARGET_DIR"] } }
-CARGO_MAKE_TOOLCHAIN_DEFAULT = { source = "${CARGO_MAKE_CI}", default_value = "nightly", mapping = { "true" = "nightly-2022-08-08", "false" = "nightly" } }
+CARGO_MAKE_TOOLCHAIN_DEFAULT = { source = "${CARGO_MAKE_CI}", default_value = "nightly" }
 CARGO_MAKE_TOOLCHAIN = { value = "${CARGO_MAKE_TOOLCHAIN_DEFAULT}", condition = { env_not_set = ["CARGO_MAKE_TOOLCHAIN"] } }
 CARGO_BUILD_TYPE = { source = "${CARGO_MAKE_PROFILE}", default_value = "debug", mapping = { "development" = "debug", "release" = "release" } }
 CARGO_PROFILE = { source = "${CARGO_BUILD_TYPE}", mapping = { "debug" = "dev", "release" = "release" } }


### PR DESCRIPTION
There are two main issues with the produced `xcframework` in its current state:

1. Rust has targets for `aarch64-apple-tvos` and `x86_64-apple-tvos`. However, there is no `aarch64-apple-tvos-sim`. This means we can build for any tvOS device, and any Intel tvOS simulator, but not an Apple Silicon tvOS simulator.
2. (non-simulator) watchOS binaries are missing platform information. I have used `lipo` to merge them with the simulator binaries, which resolves the issue but may cause other unintended problems.