### PR TITLE
Skip detaching before removing

### DIFF
--- a/crates/core/src/diff/diff.rs
+++ b/crates/core/src/diff/diff.rs
@@ -184,7 +184,6 @@ enum Op<'a> {
         /// A forked cursor of the node to be removed that iterates over descendant nodes
         cursor: Cursor<'a>,
         to: Cursor<'a>,
-        detach: bool,
     },
     /// Remove all `from` nodes
     RemoveNodes {
@@ -397,19 +396,7 @@ impl<'a> Iterator for Morph<'a> {
                     ref node,
                     cursor,
                     ref to,
-                    detach,
                 } => {
-                    let node = *node;
-
-                    if *detach {
-                        *detach = false;
-
-                        if !cursor.children().is_empty() {
-                            self.queue.push(Op::Patch(Patch::Detach { node }));
-                            continue;
-                        }
-                    }
-
                     if cursor.next().is_some() {
                         if let Node::Element(el) = cursor.node() {
                             if let Some(id) = el.id() {
@@ -425,7 +412,7 @@ impl<'a> Iterator for Morph<'a> {
                         }
                     }
 
-                    *op = Op::Patch(Patch::Remove { node });
+                    *op = Op::Patch(Patch::Remove { node: *node });
                 }
                 Op::RemoveNodes { from, to } => {
                     if !self.detached.contains(&from.node) {
@@ -433,7 +420,6 @@ impl<'a> Iterator for Morph<'a> {
                             node: from.node,
                             cursor: from.fork(),
                             to: to.fork(),
-                            detach: true,
                         });
                     }
 
@@ -567,7 +553,6 @@ impl<'a> Iterator for Morph<'a> {
                             node: from.node,
                             cursor: from.fork(),
                             to: to.fork(),
-                            detach: true,
                         });
 
                         self.advance(Advance::From, true);
@@ -620,7 +605,6 @@ impl<'a> Iterator for Morph<'a> {
                                         node: from.node,
                                         cursor: from.fork(),
                                         to: to.fork(),
-                                        detach: true,
                                     });
                                 }
 
@@ -659,7 +643,6 @@ impl<'a> Iterator for Morph<'a> {
                                         node: from.node,
                                         cursor: from.fork(),
                                         to: to.fork(),
-                                        detach: true,
                                     });
 
                                     self.advance(Advance::From, true);

--- a/crates/core/tests/diff.rs
+++ b/crates/core/tests/diff.rs
@@ -258,6 +258,29 @@ fn diff_remove_node() -> Result<(), Error> {
     )
 }
 
+#[test]
+fn diff_live_form() -> Result<(), Error> {
+    check_transformation(
+        r#"<VStack modifiers="">
+        <VStack>
+          <LiveForm id="login" phx-submit="login">
+            <TextField name="email" modifiers="">
+              Email
+            </TextField>
+            <LiveSubmitButton modifiers="">
+              <Text>Enter</Text>
+            </LiveSubmitButton>
+          </LiveForm>
+        </VStack>
+    </VStack>"#,
+        r#"<VStack modifiers="">
+        <VStack>
+          <Text>Success! Check your email for magic link</Text>
+        </VStack>
+    </VStack>"#,
+    )
+}
+
 test_fixture!("attr-value-empty-string");
 test_fixture!("change-tagname");
 test_fixture!("change-tagname-ids");


### PR DESCRIPTION
If a node would be deleted that has child nodes, currently that node will be detached before child nodes are walked to detach keyed nodes that are to be re-attached before finally removing the node that was previously detached. While this is ideal, it's currently necessary for nodes that are to be removed to have a parent node and detach removes that association, so we need to revert this optimization until remove can be used without a parent node. 