### PR TITLE
Update attributes as a single operation

### DIFF
--- a/crates/core/src/diff/diff.rs
+++ b/crates/core/src/diff/diff.rs
@@ -541,7 +541,7 @@ impl<'a> Iterator for Morph<'a> {
                             // nodes are compatible; morph attribute changes and continue
                             if to_el.name.eq(&from_el.name) && to_el.id().eq(&from_el.id()) {
                                 if from_el.attributes().ne(to_el.attributes()) {
-                                    self.queue.push(Op::Patch(Patch::UpdateAttributes {
+                                    self.queue.push(Op::Patch(Patch::SetAttributes {
                                         node: from.node,
                                         attributes: to.attributes().to_vec(),
                                     }));

--- a/crates/core/src/diff/patch.rs
+++ b/crates/core/src/diff/patch.rs
@@ -81,6 +81,11 @@ pub enum Patch {
         node: NodeRef,
         name: AttributeName,
     },
+    /// Set attributes on node
+    UpdateAttributes {
+        node: NodeRef,
+        attributes: Vec<Attribute>,
+    },
     Move(MoveTo),
 }
 
@@ -219,6 +224,12 @@ impl Patch {
                 let mut guard = doc.insert_guard();
                 guard.set_insertion_point(node);
                 guard.remove_attribute(name);
+                Some(PatchResult::Change { node })
+            }
+            Self::UpdateAttributes { node, attributes } => {
+                let mut guard = doc.insert_guard();
+                guard.set_insertion_point(node);
+                guard.replace_attributes(attributes);
                 Some(PatchResult::Change { node })
             }
             Self::Move(MoveTo::Node(node)) => {

--- a/crates/core/src/diff/patch.rs
+++ b/crates/core/src/diff/patch.rs
@@ -82,7 +82,7 @@ pub enum Patch {
         name: AttributeName,
     },
     /// Set attributes on node
-    UpdateAttributes {
+    SetAttributes {
         node: NodeRef,
         attributes: Vec<Attribute>,
     },
@@ -226,7 +226,7 @@ impl Patch {
                 guard.remove_attribute(name);
                 Some(PatchResult::Change { node })
             }
-            Self::UpdateAttributes { node, attributes } => {
+            Self::SetAttributes { node, attributes } => {
                 let mut guard = doc.insert_guard();
                 guard.set_insertion_point(node);
                 guard.replace_attributes(attributes);

--- a/crates/core/src/dom/mod.rs
+++ b/crates/core/src/dom/mod.rs
@@ -440,6 +440,19 @@ impl Document {
         }
     }
 
+    /// If node is an element, replace attributes and return previous
+    pub fn replace_attributes(
+        &mut self,
+        node: NodeRef,
+        attributes: Vec<Attribute>,
+    ) -> Option<Vec<Attribute>> {
+        if let Node::Element(ref mut elem) = &mut self.nodes[node] {
+            Some(mem::replace(&mut elem.attributes, attributes))
+        } else {
+            None
+        }
+    }
+
     /// Removes all attributes from `node` for which `predicate` returns false.
     pub fn remove_attributes_by<P>(&mut self, node: NodeRef, predicate: P)
     where
@@ -567,6 +580,12 @@ pub trait DocumentBuilder {
         assert!(self
             .document_mut()
             .set_attribute(ip, name.into(), value.into()));
+    }
+
+    /// Replace attributes
+    fn replace_attributes(&mut self, attributes: Vec<Attribute>) {
+        let ip = self.insertion_point();
+        self.document_mut().replace_attributes(ip, attributes);
     }
 
     /// Removes any instance of an attribute named `name`


### PR DESCRIPTION
Previously attributes were synchronized in place using `Patch::AddAttribute`, `Patch::UpdateAttribute` and `Patch::RemoveAttributeByName` with each operation applying with a respective `PatchResult::Change`. The problem with this approach, from an FFI perspective, is that immutable references cannot exist beyond the lifetime of the change handler callback without there being a risk of a successive change invalidating this memory. Changing to using `Patch::UpdateAttributes` to replace all attributes as a memory swap ensures that handlers can rely on the underlying memory to not be invalidated prior to the next document merge