### PR TITLE
Add tvOS for apple silicon and add xcframework release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust Nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
-          default: true
+          components: rust-src
+          targets:
+            aarch64-apple-ios-sim
+            aarch64-apple-ios
+            x86_64-apple-ios
+            aarch64-apple-darwin
+            x86_64-apple-darwin
 
       - name: Cache
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   TOOLCHAIN: nightly
+  CARGO_MAKE_TOOLCHAIN: nightly
   CARGO_MAKE_PROFILE: dev
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: xcframework-release
+
+on:
+  - workflow_dispatch
+  - push
+
+env:
+  CARGO_TERM_COLOR: always
+  TOOLCHAIN: nightly
+  CARGO_MAKE_PROFILE: dev
+
+jobs:
+  release-xcframework:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust Nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.TOOLCHAIN }}
+          default: true
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: ${{ github.workflow }}-${{ github.job }}-toolchain-${{ env.TOOLCHAIN }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make
+
+      - name: set profile
+        if: github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          echo "CARGO_MAKE_PROFILE=release" >> $GITHUB_ENV
+
+      - name: Build XCFramework
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: xcframework
+
+      - uses: actions/upload-artifact@v3
+        with:
+          retention-days: 5
+          name: liveview_native_core.xcframework
+          path: target/swift/liveview_native_core.xcframework
+
+      - uses: actions/github-script@v6
+        if: github.ref == 'refs/heads/main'
+        continue-on-error: true
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            let release
+            try {
+              release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: 'nightly'
+              })
+            } catch(e) {
+              console.error(e)
+              return
+            }
+
+            await github.rest.repos.deleteRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.data.id
+            })
+
+            await github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'tags/nightly'
+            })
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          files: liveview_native_core.xcframework
+          name: nightly
+          tag_name: nightly

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -121,7 +121,7 @@ args = [
     "-library", "${CARGO_TARGET_DIR}/universal/macos/libliveview_native_core.a",
     "-headers", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/crates/core/c_src/include",
 	# iOS
-    "-library", "${CARGO_TARGET_DIR}/aarch64-apple-ios/debug/libliveview_native_core.a",
+    "-library", "${CARGO_TARGET_DIR}/aarch64-apple-ios/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
     "-headers", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/crates/core/c_src/include",
 	# iOS sim
     "-library", "${CARGO_TARGET_DIR}/universal/ios-sim/libliveview_native_core.a",
@@ -135,12 +135,14 @@ args = [
     "-library", "${CARGO_TARGET_DIR}/universal/watchos-sim/libliveview_native_core.a",
     "-headers", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/crates/core/c_src/include",
 	# tvOS
-    "-library", "${CARGO_TARGET_DIR}/aarch64-apple-tvos/debug/libliveview_native_core.a",
+    "-library", "${CARGO_TARGET_DIR}/aarch64-apple-tvos/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
     "-headers", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/crates/core/c_src/include",
-    "-library", "${CARGO_TARGET_DIR}/x86_64-apple-tvos/debug/libliveview_native_core.a",
+
+    # tvOS sim
+    "-library", "${CARGO_TARGET_DIR}/universal/tvos-sim/libliveview_native_core.a",
     "-headers", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/crates/core/c_src/include",
 ]
-dependencies = ["build-macos", "build-ios", "build-watchos", "build-tvos", "create-lipo-universal-directories", "lipo-macos", "lipo-ios-sim", "lipo-watchos-sim", "remove-existing-xcframework"]
+dependencies = ["build-macos", "build-ios", "build-watchos", "build-tvos", "create-lipo-universal-directories", "lipo-macos", "lipo-tvos-sim", "lipo-ios-sim", "lipo-watchos-sim", "remove-existing-xcframework"]
 
 [tasks.remove-existing-xcframework]
 workspace = false
@@ -151,14 +153,14 @@ script = "rm -r ${CARGO_TARGET_DIR}/swift/liveview_native_core.xcframework"
 [tasks.create-lipo-universal-directories]
 workspace = false
 private = true
-script = "mkdir -p ${CARGO_TARGET_DIR}/universal/macos/ ${CARGO_TARGET_DIR}/universal/ios-sim/ ${CARGO_TARGET_DIR}/universal/watchos-sim/"
+script = "mkdir -p ${CARGO_TARGET_DIR}/universal/macos/ ${CARGO_TARGET_DIR}/universal/ios-sim/ ${CARGO_TARGET_DIR}/universal/watchos-sim/ ${CARGO_TARGET_DIR}/universal/tvos-sim/"
 
 [tasks.build-macos]
 workspace = false
 category = "Build"
 description = "Compiles for all targets needed to produce a universal library for macOS"
 command = "rustup"
-args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "--target", "aarch64-apple-darwin", "--target", "x86_64-apple-darwin", "-p", "liveview-native-core"]
+args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "--profile", "${CARGO_PROFILE}", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "--target", "aarch64-apple-darwin", "--target", "x86_64-apple-darwin", "-p", "liveview-native-core"]
 dependencies = ["install-targets"]
 
 [tasks.build-ios]
@@ -166,7 +168,7 @@ workspace = false
 category = "Build"
 description = "Compiles for all targets needed to produce a universal library for iOS"
 command = "rustup"
-args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "--target", "aarch64-apple-ios", "--target", "aarch64-apple-ios-sim", "--target", "x86_64-apple-ios", "-p", "liveview-native-core"]
+args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "--profile", "${CARGO_PROFILE}", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "--target", "aarch64-apple-ios", "--target", "aarch64-apple-ios-sim", "--target", "x86_64-apple-ios", "-p", "liveview-native-core"]
 dependencies = ["install-targets"]
 
 [tasks.build-watchos]
@@ -174,7 +176,7 @@ workspace = false
 category = "Build"
 description = "Compiles for all targets needed to produce a universal library for watchOS"
 command = "rustup"
-args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "-Z", "build-std", "--target", "arm64_32-apple-watchos", "--target", "armv7k-apple-watchos", "--target", "aarch64-apple-watchos-sim", "--target", "x86_64-apple-watchos-sim", "-p", "liveview-native-core"]
+args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "--profile", "${CARGO_PROFILE}", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "-Z", "build-std", "--target", "arm64_32-apple-watchos", "--target", "armv7k-apple-watchos", "--target", "aarch64-apple-watchos-sim", "--target", "x86_64-apple-watchos-sim", "-p", "liveview-native-core"]
 dependencies = ["install-targets"]
 
 [tasks.build-tvos]
@@ -182,7 +184,7 @@ workspace = false
 category = "Build"
 description = "Compiles for all targets needed to produce a universal library for tvOS"
 command = "rustup"
-args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "-Z", "build-std", "--target", "aarch64-apple-tvos", "--target", "x86_64-apple-tvos", "-p", "liveview-native-core"]
+args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "--profile", "${CARGO_PROFILE}", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "-Z", "build-std", "--target", "aarch64-apple-tvos", "--target", "x86_64-apple-tvos", "--target", "aarch64-apple-tvos-sim", "-p", "liveview-native-core"]
 dependencies = ["install-targets"]
 
 [tasks.lipo-macos]
@@ -193,8 +195,8 @@ description = "Combines macOS targets into a universal binary"
 command = "xcrun"
 args = [
 	"lipo", "-create",
-	"${CARGO_TARGET_DIR}/aarch64-apple-darwin/debug/libliveview_native_core.a",
-	"${CARGO_TARGET_DIR}/x86_64-apple-darwin/debug/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/aarch64-apple-darwin/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/x86_64-apple-darwin/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
 	"-output", "${CARGO_TARGET_DIR}/universal/macos/libliveview_native_core.a"
 ]
 
@@ -207,9 +209,23 @@ command = "xcrun"
 args = [
 	"lipo",
 	"-create",
-	"${CARGO_TARGET_DIR}/aarch64-apple-ios-sim/debug/libliveview_native_core.a",
-	"${CARGO_TARGET_DIR}/x86_64-apple-ios/debug/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/aarch64-apple-ios-sim/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/x86_64-apple-ios/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
 	"-output", "${CARGO_TARGET_DIR}/universal/ios-sim/libliveview_native_core.a"
+]
+
+[tasks.lipo-tvos-sim]
+dependencies = ["create-lipo-universal-directories"]
+workspace = false
+category = "Build"
+description = "Combines tvOS simulator targets into a universal binary"
+command = "xcrun"
+args = [
+	"lipo",
+	"-create",
+	"${CARGO_TARGET_DIR}/aarch64-apple-tvos-sim/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/x86_64-apple-tvos/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
+	"-output", "${CARGO_TARGET_DIR}/universal/tvos-sim/libliveview_native_core.a"
 ]
 
 [tasks.lipo-watchos-sim]
@@ -220,10 +236,10 @@ description = "Combines watchOS simulator targets into a universal binary"
 command = "xcrun"
 args = [
 	"lipo", "-create",
-	"${CARGO_TARGET_DIR}/aarch64-apple-watchos-sim/debug/libliveview_native_core.a",
-	"${CARGO_TARGET_DIR}/x86_64-apple-watchos-sim/debug/libliveview_native_core.a",
-	"${CARGO_TARGET_DIR}/arm64_32-apple-watchos/debug/libliveview_native_core.a",
-	"${CARGO_TARGET_DIR}/armv7k-apple-watchos/debug/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/aarch64-apple-watchos-sim/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/x86_64-apple-watchos-sim/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/arm64_32-apple-watchos/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/armv7k-apple-watchos/${CARGO_BUILD_TYPE}/libliveview_native_core.a",
 	"-output", "${CARGO_TARGET_DIR}/universal/watchos-sim/libliveview_native_core.a"
 ]
 


### PR DESCRIPTION
This is to add the apple silicon tvOS simulator support and also add some CI for releases.

This CI addition is based off [my personal resume CI](https://github.com/simlay/resume/blob/143b0ce3f6ed3d4f1c14fe6a6e261ac6b895a090/.github/workflows/release.yml#L21-L63). Right now it will just create a github "release" called `nightly` when a PR is merged (assuming CI actually works). This could also use a "tag" as a workflow parameter but it's been my experience that adding lots of options to github CI tends to make it more brittle. Perhaps a manual change of name for a given release from "nightly" (to a version) might be best.