### PR TITLE
Bump package versions to 0.4.0-alpha-2

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,9 +23,6 @@ updates:
     directory: "/tests/support/test_server/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"] # ignore patch updates
 
   - package-ecosystem: "swift" 
     directory: "/" 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   TOOLCHAIN: nightly
   CARGO_MAKE_TOOLCHAIN: nightly
   ANDROID_API: 33
-  ANDROID_NDK_VERSION: 25.2.9519653
+  ANDROID_NDK_VERSION: 26.3.11579264
 
 jobs:
   kotiln_integration_tests:
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [
           'macos-14',
-          'ubuntu-latest',
+          'ubuntu-24.04',
         ]
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
            ./gradlew build --scan
 
       - name: Run build with Gradle wrapper
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         working-directory: ./crates/core/liveview-native-core-jetpack/
         env:
           RANLIB: "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib"
@@ -307,7 +307,7 @@ jobs:
 
   android_simulator_tests:
     # rust cross-compilation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-alpha"
+version = "0.4.0-alpha-2"
 rust-version = "1.64"
 authors = [
     "Paul Schoenfelder <paulschoenfelder@gmail.com>",

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ if useLocalFramework {
         path: "./target/uniffi/swift/liveview_native_core.xcframework"
     )
 } else {
-    let releaseTag = "0.3.0-alpha"
+    let releaseTag = "0.4.0-alpha-2"
     let releaseChecksum = "f3972f4d40732c884c98426b28550376abaff20a3490b73367ad170f1f0bcca9"
     liveview_native_core_framework = .binaryTarget(
         name: "liveview_native_core",

--- a/crates/core/liveview-native-core-jetpack/core/build.gradle.kts
+++ b/crates/core/liveview-native-core-jetpack/core/build.gradle.kts
@@ -38,8 +38,10 @@ android {
         getByName("release") {
             isMinifyEnabled = false
         }
+        /*
         create("releaseDesktop") {
         }
+        */
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -54,12 +56,14 @@ android {
             withSourcesJar()
             withJavadocJar()
         }
+        /*
         singleVariant("releaseDesktop") {
             withSourcesJar()
             withJavadocJar()
         }
+        */
     }
-    ndkVersion = "25.2.9519653"
+    ndkVersion = "26.3.11579264"
 
     sourceSets {
         getByName("main") {
@@ -88,9 +92,6 @@ android {
             if (is_linux) {
                 dylib_file = rootProject.file("../../../target/debug/libliveview_native_core.so")
             }
-
-            // Runs the bindings generation, note that you must have uniffi-bindgen installed and in your PATH environment variable
-            // TODO: Ensure that the aarch64-apple-darwin build is finished.
 
             commandLine(
                 "cargo",
@@ -165,6 +166,7 @@ publishing {
             }
         }
     }
+    /*
     publications {
         register<MavenPublication>("releaseDesktop")  {
             groupId = "org.phoenixframework"
@@ -176,4 +178,5 @@ publishing {
             }
         }
     }
+    */
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -11,7 +11,7 @@ before_install:
   - yes | sdkmanager --licenses
   - yes | sdkmanager --update
   - yes | sdkmanager --uninstall "ndk-bundle"
-  - yes | sdkmanager --install "ndk;25.2.9519653"
+  - yes | sdkmanager --install "ndk;26.3.11579264"
   - yes | sdkmanager --install "cmake;3.22.1"
   # Install JDK 17 and using it for the rest of the build
   - sdk install java 17.0.3-tem
@@ -19,7 +19,7 @@ before_install:
 install:
   - echo "Running a custom install command"
   - uname -a
-  - ls $ANDROID_HOME/ndk/25.2.9519653/toolchains/llvm/prebuilt/*/bin/*
+  - ls $ANDROID_HOME/ndk/26.3.11579264/toolchains/llvm/prebuilt/*/bin/*
   - cd ./crates/core/liveview-native-core-jetpack/
   - source "$HOME/.cargo/env"
   - ./gradlew buildDebugStaticLib
@@ -30,4 +30,4 @@ env:
   RUST_ANDROID_GRADLE_RUSTC_COMMAND: "/home/jitpack/.cargo/bin/rustc"
   RUST_ANDROID_GRADLE_CARGO_COMMAND: "/home/jitpack/.cargo/bin/cargo"
   RUST_ANDROID_GRADLE_RUSTUP_CHANNEL: "nightly"
-  RANLIB: "/opt/android-sdk-linux/ndk/25.2.9519653/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib"
+  RANLIB: "/opt/android-sdk-linux/ndk/26.3.11579264/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib"


### PR DESCRIPTION
In the jitpack bundle, I noticed extra build artifacts that might be messing up my builds for the jetpack client.

* Change mix dependabot versions to include patches
* Update the android ndk version to 26.3.11579264 as this what Github actions CI defaults to.