### PR TITLE
Multiple bug fixes on file uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,7 +1196,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "liveview-native-core"
-version = "0.4.0-alpha-11"
+version = "0.4.0-alpha-12"
 dependencies = [
  "Inflector",
  "cranelift-entity",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "liveview_native_core_wasm"
-version = "0.4.0-alpha-11"
+version = "0.4.0-alpha-12"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "0.4.0-alpha-11"
+version = "0.4.0-alpha-12"
 dependencies = [
  "uniffi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,7 @@ dependencies = [
  "html5gum",
  "image",
  "log",
+ "mime",
  "paste",
  "petgraph",
  "phoenix_channels_client",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -49,6 +49,7 @@ cranelift-entity = { version = "0.113" }
 fixedbitset = { version = "0.4" }
 fxhash = { version = "0.2" }
 html5gum = { git = "https://github.com/liveviewnative/html5gum", branch = "lvn" }
+mime = "0.3.17"
 petgraph = { version = "0.6", default-features = false, features = ["graphmap"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/crates/core/liveview-native-core-jetpack/core/src/test/java/org/phoenixframework/liveview_jetpack/DocumentTest.kt
+++ b/crates/core/liveview-native-core-jetpack/core/src/test/java/org/phoenixframework/liveview_jetpack/DocumentTest.kt
@@ -9,7 +9,6 @@ import org.phoenixframework.liveviewnative.core.ChangeType
 import org.phoenixframework.liveviewnative.core.ConnectOpts
 import org.phoenixframework.liveviewnative.core.Document
 import org.phoenixframework.liveviewnative.core.DocumentChangeHandler
-import org.phoenixframework.liveviewnative.core.LiveFile
 import org.phoenixframework.liveviewnative.core.LiveSocket
 import org.phoenixframework.liveviewnative.core.NodeData
 import org.phoenixframework.liveviewnative.core.NodeRef
@@ -19,13 +18,12 @@ class SocketTest {
     fun simple_connect() = runTest {
         var live_socket = LiveSocket.connect("http://127.0.0.1:4001/upload", "jetpack", null)
         var live_channel = live_socket.joinLiveviewChannel(null, null)
-        var phx_id = live_channel.getPhxRefFromUploadJoinPayload()
         // This is a PNG located at crates/core/tests/support/tinycross.png
         var base64TileImg =
                 "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gEdFQog0ycfAgAAAIJJREFUOMulU0EOwCAIK2T/f/LYwWAAgZGtJzS1BbVEuEVAAACCQOsKlkOrEicwgeVz5tC5R1yrDdnKuo6j6J5ydgd+npOUHfaGEJkQq+6cQNVqP1oQiCJxvAjGT3Dn3l1sKpAdfhPhqXP5xDYLXz7SkYUuUNnrcBWULkRlFqZxtvwH8zGCEN6LErUAAAAASUVORK5CYII="
 
         val contents = Base64.getDecoder().decode(base64TileImg)
-        var live_file = LiveFile(contents, "png", "foobar.png", phx_id)
+        var live_file = live_channel.constructUpload(contents, "png", "foobar.png", "avatar")
         live_channel.uploadFile(live_file)
     }
 }
@@ -36,13 +34,13 @@ class SocketTestOpts {
         var opts = ConnectOpts()
         var live_socket = LiveSocket.connect("http://127.0.0.1:4001/upload", "jetpack", opts)
         var live_channel = live_socket.joinLiveviewChannel(null, null)
-        var phx_id = live_channel.getPhxRefFromUploadJoinPayload()
+
         // This is a PNG located at crates/core/tests/support/tinycross.png
         var base64TileImg =
                 "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gEdFQog0ycfAgAAAIJJREFUOMulU0EOwCAIK2T/f/LYwWAAgZGtJzS1BbVEuEVAAACCQOsKlkOrEicwgeVz5tC5R1yrDdnKuo6j6J5ydgd+npOUHfaGEJkQq+6cQNVqP1oQiCJxvAjGT3Dn3l1sKpAdfhPhqXP5xDYLXz7SkYUuUNnrcBWULkRlFqZxtvwH8zGCEN6LErUAAAAASUVORK5CYII="
 
         val contents = Base64.getDecoder().decode(base64TileImg)
-        var live_file = LiveFile(contents, "png", "foobar.png", phx_id)
+        var live_file = live_channel.constructUpload(contents, "png", "foobar.png", "avatar")
         live_channel.uploadFile(live_file)
     }
 }

--- a/crates/core/liveview-native-core-swift/Tests/LiveViewNativeCoreTests/LiveViewNativeCoreSocketTests.swift
+++ b/crates/core/liveview-native-core-swift/Tests/LiveViewNativeCoreTests/LiveViewNativeCoreSocketTests.swift
@@ -50,10 +50,9 @@ final class LiveViewNativeCoreUploadTests: XCTestCase {
         let live_socket = try await LiveSocket(upload_url, "swiftui", .none)
         let live_channel = try await live_socket.joinLiveviewChannel(.none, .none)
 
-        let phx_id = try live_channel.getPhxRefFromUploadJoinPayload()
         let image: Data! = Data(base64Encoded: base64TileImg)
 
-        let live_file = LiveFile(image, "png", "foobar.png", phx_id)
+        let live_file = try live_channel.constructUpload(image, "png", "foobar.png", "avatar")
         try await live_channel.uploadFile(live_file)
     }
 }

--- a/crates/core/src/dom/ffi.rs
+++ b/crates/core/src/dom/ffi.rs
@@ -3,6 +3,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use phoenix_channels_client::JSON;
+
 pub use super::{
     attribute::Attribute,
     node::{Node, NodeData, NodeRef},
@@ -57,7 +59,16 @@ impl Document {
         self.inner.lock().expect("lock poisoned!").event_callback = Some(Arc::from(handler));
     }
 
-    pub fn merge_fragment_json(&self, json: &str) -> Result<(), RenderError> {
+    pub fn merge_fragment_json_value(&self, json: JSON) -> Result<(), RenderError> {
+        let json = serde_json::Value::from(json);
+        self.inner
+            .lock()
+            .expect("lock poisoned!")
+            .merge_fragment_json(json)
+    }
+
+    pub fn merge_fragment_json_string(&self, json: String) -> Result<(), RenderError> {
+        let json = serde_json::from_str(&json)?;
         self.inner
             .lock()
             .expect("lock poisoned!")

--- a/crates/core/src/dom/ffi.rs
+++ b/crates/core/src/dom/ffi.rs
@@ -24,6 +24,13 @@ impl From<super::Document> for Document {
     }
 }
 
+// crate local api
+impl Document {
+    pub(crate) fn inner(&self) -> Arc<Mutex<super::Document>> {
+        self.inner.clone()
+    }
+}
+
 #[uniffi::export]
 impl Document {
     #[uniffi::constructor]

--- a/crates/core/src/dom/ffi.rs
+++ b/crates/core/src/dom/ffi.rs
@@ -57,6 +57,10 @@ impl Document {
             .merge_fragment_json(json)
     }
 
+    pub fn next_upload_id(&self) -> u64 {
+        self.inner.lock().expect("lock poisoned!").next_upload_id()
+    }
+
     pub fn root(&self) -> Arc<NodeRef> {
         self.inner.lock().expect("lock poisoned!").root().into()
     }

--- a/crates/core/src/dom/mod.rs
+++ b/crates/core/src/dom/mod.rs
@@ -16,6 +16,7 @@ use cranelift_entity::{packed_option::PackedOption, EntityRef, PrimaryMap, Secon
 use fixedbitset::FixedBitSet;
 use fxhash::{FxBuildHasher, FxHashMap};
 use petgraph::Direction;
+use phoenix_channels_client::JSON;
 use smallstr::SmallString;
 use smallvec::SmallVec;
 
@@ -528,8 +529,8 @@ impl Document {
         Ok(document)
     }
 
-    pub fn merge_fragment_json(&mut self, json: &str) -> Result<(), RenderError> {
-        let fragment: RootDiff = serde_json::from_str(json).map_err(RenderError::from)?;
+    pub fn merge_fragment_json(&mut self, value: serde_json::Value) -> Result<(), RenderError> {
+        let fragment: RootDiff = serde_json::from_value(value).map_err(RenderError::from)?;
 
         let root = if let Some(root) = &self.fragment_template {
             root.clone().merge(fragment)?
@@ -593,6 +594,8 @@ pub enum EventType {
     Changed, // { change: ChangeType },
 }
 
+/// Implements the change handling logic for inbound virtual dom
+/// changes. Your logic for handling document patches should go here.
 #[uniffi::export(callback_interface)]
 pub trait DocumentChangeHandler: Send + Sync {
     /// This callback should implement your dom manipulation logic

--- a/crates/core/src/dom/mod.rs
+++ b/crates/core/src/dom/mod.rs
@@ -155,8 +155,9 @@ impl Document {
     ///  replicates the behavior found at the following
     /// https://github.com/phoenixframework/phoenix_live_view/blob/b59bede3fcec6995f1d5876a520af8badc4bb7fb/assets/js/phoenix_live_view/live_uploader.js#L13-L24
     pub fn next_upload_id(&mut self) -> u64 {
+        let next = self.upload_ct;
         self.upload_ct += 1;
-        self.upload_ct
+        next
     }
 
     /// Obtains a `DocumentBuilder` with which you can extend/modify this document

--- a/crates/core/src/dom/mod.rs
+++ b/crates/core/src/dom/mod.rs
@@ -82,7 +82,7 @@ pub struct Document {
     /// This allows for looking up a node directly and modifying it, rather than needing to traverse the
     /// document.
     ids: BTreeMap<SmallString<[u8; 16]>, NodeRef>,
-    /// A count of the number of uploads, the server expects each upload to have an acending unique ID.
+    /// A count of the number of uploads, the server expects each upload to have an ascending unique ID.
     upload_ct: u64,
 }
 impl fmt::Debug for Document {

--- a/crates/core/src/dom/mod.rs
+++ b/crates/core/src/dom/mod.rs
@@ -82,6 +82,8 @@ pub struct Document {
     /// This allows for looking up a node directly and modifying it, rather than needing to traverse the
     /// document.
     ids: BTreeMap<SmallString<[u8; 16]>, NodeRef>,
+    /// A count of the number of uploads, the server expects each upload to have an acending unique ID.
+    upload_ct: u64,
 }
 impl fmt::Debug for Document {
     #[inline]
@@ -130,6 +132,7 @@ impl Document {
             ids: Default::default(),
             fragment_template: None,
             event_callback: None,
+            upload_ct: 0,
         }
     }
 
@@ -146,6 +149,14 @@ impl Document {
     /// Parses a `Document` from a file at the given path
     pub fn parse_file<P: AsRef<Path>>(path: P) -> Result<Self, parser::ParseError> {
         parser::parse(std::fs::File::open(path)?)
+    }
+
+    /// Returns an ascending `ref` id
+    ///  replicates the behavior found at the following
+    /// https://github.com/phoenixframework/phoenix_live_view/blob/b59bede3fcec6995f1d5876a520af8badc4bb7fb/assets/js/phoenix_live_view/live_uploader.js#L13-L24
+    pub fn next_upload_id(&mut self) -> u64 {
+        self.upload_ct += 1;
+        self.upload_ct
     }
 
     /// Obtains a `DocumentBuilder` with which you can extend/modify this document

--- a/crates/core/src/live_socket/channel.rs
+++ b/crates/core/src/live_socket/channel.rs
@@ -161,6 +161,7 @@ impl LiveChannel {
     }
 
     pub async fn validate_upload(&self, file: &LiveFile) -> Result<Payload, LiveSocketError> {
+        // TODO: move this into protocol
         let validate_event_payload = serde_json::json!(
         {
           "type" : "form",
@@ -178,7 +179,7 @@ impl LiveChannel {
           },
         });
 
-        let mime_type: mime::Mime =
+        let _mime_type: mime::Mime =
             file.mime_type
                 .parse()
                 .map_err(|e| LiveSocketError::MimeType {
@@ -205,6 +206,7 @@ impl LiveChannel {
         let value = serde_json::Value::from(json.clone());
         let _s: protocol::ValidateResponse = serde_json::from_value(value)?;
 
+        // TODO: move this into protocol
         /* Validate "okay" response looks like:
         {
         "diff": {
@@ -233,6 +235,7 @@ impl LiveChannel {
             .as_ref()
             .ok_or(LiveSocketError::NoInputRefInDocument)?;
 
+        // TODO: move this into protocol
         let event_string = format!(
             r#"{{
             "ref":"{}",
@@ -293,6 +296,7 @@ impl LiveChannel {
             "errors":[["0", "too_large"]],
         }
                 */
+        // TODO: move this into protocol
         let mut upload_config = UploadConfig::default();
         let upload_token = match allow_upload_resp {
             Payload::JSONPayload {
@@ -398,6 +402,7 @@ impl LiveChannel {
 
             if progress < 100 {
                 // We must inform the server we've reached 100% upload via the progress.
+                // TODO: move this into protocol
                 let progress_event_string = format!(
                     r#"{{"event":null, "ref":"{}", "entry_ref":"{}", "progress":{} }}"#,
                     upload_id, file.ref_id, progress,
@@ -420,7 +425,7 @@ impl LiveChannel {
             }
         }
 
-        // We must inform the server we've reached 100% upload via the progress.
+        // TODO: move this into protocol
         let progress_event_string = format!(
             r#"{{"event":null, "ref":"{}", "entry_ref":"{}", "progress": 100 }}"#,
             upload_id, file.ref_id,

--- a/crates/core/src/live_socket/error.rs
+++ b/crates/core/src/live_socket/error.rs
@@ -11,6 +11,8 @@ use crate::{
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum LiveSocketError {
+    #[error("Expected Json Payload, Was Binary")]
+    PayloadNotJson,
     #[error("Could Not Parse Mime - {error}")]
     MimeType { error: String },
     #[error("Invalid Header - {error}")]

--- a/crates/core/src/live_socket/error.rs
+++ b/crates/core/src/live_socket/error.rs
@@ -11,6 +11,8 @@ use crate::{
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum LiveSocketError {
+    #[error("Could Not Parse Mime - {error}")]
+    MimeType { error: String },
     #[error("Invalid Header - {error}")]
     InvalidHeader { error: String },
     #[error("Invalid Method - {error}")]

--- a/crates/core/src/live_socket/form.rs
+++ b/crates/core/src/live_socket/form.rs
@@ -7,7 +7,6 @@ use crate::dom::NodeRef;
 
 use super::{channel::LiveFile, error::LiveSocketError, LiveChannel};
 
-#[derive(uniffi::Object)]
 pub enum FormValue {
     File(LiveFile),
     Value(String),
@@ -15,13 +14,12 @@ pub enum FormValue {
 
 /// Contains abstractions for form data as well as traits for instrumenting form changes
 /// and submissions
-#[derive(uniffi::Object)]
-pub struct FormModel {
+pub struct Form {
     /// The dom element that this form corresponds to
     node_ref: NodeRef,
-    /// The event name that triggers on `change` events
+    /// The event name that triggers on `phx-change` events
     on_change: Option<String>,
-    /// The event name that triggers on `submit` events
+    /// The event name that triggers on `phx-submit` events
     on_submit: Option<String>,
     /// The name of the form
     target_name: String,
@@ -29,9 +27,9 @@ pub struct FormModel {
     fields: HashMap<String, FormValue>,
 }
 
-impl FormModel {
+impl Form {
     pub fn new(node_ref: NodeRef, target_name: String, fields: HashMap<String, FormValue>) -> Self {
-        FormModel {
+        Form {
             on_change: None,
             on_submit: None,
             node_ref,
@@ -58,8 +56,13 @@ impl FormModel {
         I: Iterator<Item = (S, FormValue)>,
     {
         // apply the changes
+        for (k, v) in values {
+            self.fields.insert(k.as_ref().into(), v);
+        }
 
         // if needed send the message
+        if let Some(event_name) = self.on_change.as_ref() {}
+
         Ok(())
     }
 }

--- a/crates/core/src/live_socket/form.rs
+++ b/crates/core/src/live_socket/form.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+
+use phoenix_channels_client::url::UrlQuery;
+use uniffi::Object;
+
+use crate::dom::NodeRef;
+
+use super::{channel::LiveFile, error::LiveSocketError, LiveChannel};
+
+#[derive(uniffi::Object)]
+pub enum FormValue {
+    File(LiveFile),
+    Value(String),
+}
+
+/// Contains abstractions for form data as well as traits for instrumenting form changes
+/// and submissions
+#[derive(uniffi::Object)]
+pub struct FormModel {
+    /// The dom element that this form corresponds to
+    node_ref: NodeRef,
+    /// The event name that triggers on `change` events
+    on_change: Option<String>,
+    /// The event name that triggers on `submit` events
+    on_submit: Option<String>,
+    /// The name of the form
+    target_name: String,
+    /// Current stringified name, value pairs for the inputs
+    fields: HashMap<String, FormValue>,
+}
+
+impl FormModel {
+    pub fn new(node_ref: NodeRef, target_name: String, fields: HashMap<String, FormValue>) -> Self {
+        FormModel {
+            on_change: None,
+            on_submit: None,
+            node_ref,
+            target_name,
+            fields,
+        }
+    }
+
+    /// Triggers a submit event with the current values
+    pub async fn submit(&self, channel: &LiveChannel) -> Result<(), LiveSocketError> {
+        // send the message, upload the chunks in a loop
+        Ok(())
+    }
+
+    /// Updates the values in the form, if there is an `phx-change` event
+    /// hook set up, it attempts to send one.
+    pub async fn update_values<S, I>(
+        &mut self,
+        values: I,
+        channel: &LiveChannel,
+    ) -> Result<(), LiveSocketError>
+    where
+        S: AsRef<str>,
+        I: Iterator<Item = (S, FormValue)>,
+    {
+        // apply the changes
+
+        // if needed send the message
+        Ok(())
+    }
+}

--- a/crates/core/src/live_socket/mod.rs
+++ b/crates/core/src/live_socket/mod.rs
@@ -12,19 +12,25 @@ pub use socket::LiveSocket;
 #[derive(uniffi::Object)]
 pub struct LiveFile {
     contents: Vec<u8>,
-    file_type: String,
-    name: String,
-    phx_id: String,
+    mime_type: String,
+    path: String,
+    phx_target_name: String,
 }
+
 #[uniffi::export]
 impl LiveFile {
     #[uniffi::constructor]
-    pub fn new(contents: Vec<u8>, file_type: String, name: String, phx_id: String) -> Self {
+    pub fn new(
+        contents: Vec<u8>,
+        mime_type: String,
+        file_path: String,
+        phx_target_name: String,
+    ) -> Self {
         Self {
             contents,
-            file_type,
-            name,
-            phx_id,
+            mime_type,
+            path: file_path,
+            phx_target_name,
         }
     }
 }

--- a/crates/core/src/live_socket/mod.rs
+++ b/crates/core/src/live_socket/mod.rs
@@ -1,5 +1,6 @@
 mod channel;
 mod error;
+mod form;
 mod protocol;
 mod socket;
 

--- a/crates/core/src/live_socket/mod.rs
+++ b/crates/core/src/live_socket/mod.rs
@@ -1,5 +1,6 @@
 mod channel;
 mod error;
+mod protocol;
 mod socket;
 
 #[cfg(test)]
@@ -9,31 +10,6 @@ pub use channel::LiveChannel;
 use error::{LiveSocketError, UploadError};
 pub use socket::LiveSocket;
 
-#[derive(uniffi::Object)]
-pub struct LiveFile {
-    contents: Vec<u8>,
-    mime_type: String,
-    path: String,
-    phx_target_name: String,
-}
-
-#[uniffi::export]
-impl LiveFile {
-    #[uniffi::constructor]
-    pub fn new(
-        contents: Vec<u8>,
-        mime_type: String,
-        file_path: String,
-        phx_target_name: String,
-    ) -> Self {
-        Self {
-            contents,
-            mime_type,
-            path: file_path,
-            phx_target_name,
-        }
-    }
-}
 pub struct UploadConfig {
     chunk_size: u64,
     max_file_size: u64,

--- a/crates/core/src/live_socket/protocol.rs
+++ b/crates/core/src/live_socket/protocol.rs
@@ -1,28 +1,62 @@
+use super::channel::LiveFile;
+use phoenix_channels_client::{Event, Payload};
+use serde::{Deserialize, Serialize};
+
 use std::collections::HashMap;
 
 /// Shared protocol structs and parsing helpers,
 /// In the future some of this code should be generated from a json schema
-use serde::{Deserialize, Serialize};
 
 /// an ascending nonce as assigned per upload for the live channel.
 pub type UploadId = u64;
 
-pub type ValidateResponse = CallResponse<serde_json::Value>;
+/// response to `allow_upload` events
+pub type UploadValidateResp = response::CallResponse<serde_json::Value>;
 
 /// A type mapping fragment indices (as represented by u64's) to
 /// Some type
 pub type IdMap<T> = HashMap<u64, T>;
 
-/// Generic call wrapper
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
-pub enum CallResponse<T> {
-    Error { error: T },
-    Diff { diff: T },
+mod request {
+    use super::*;
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct FromChangedMessage {
+        pub r#ref: String,
+        pub entries: Vec<FormValue>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(untagged)]
+    pub enum FormValue {
+        Field(String, String),
+        FileUpload(UploadEntryDescriptor),
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct UploadEntryDescriptor {
+        pub r#ref: String,
+        pub relative_path: String,
+        pub name: String,
+        pub r#type: String,
+        pub size: u64,
+    }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ValidateUpload {
-    #[serde(flatten)]
-    id_map: HashMap<UploadId, IdMap<IdMap<String>>>,
+mod response {
+    use super::*;
+
+    /// Generic call wrapper
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(untagged)]
+    pub enum CallResponse<T> {
+        Error { error: T },
+        Diff { diff: T },
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct ValidateUpload {
+        #[serde(flatten)]
+        id_map: HashMap<UploadId, IdMap<IdMap<String>>>,
+    }
 }

--- a/crates/core/src/live_socket/protocol.rs
+++ b/crates/core/src/live_socket/protocol.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+
+/// Shared protocol structs and parsing helpers,
+/// In the future some of this code should be generated from a json schema
+use serde::{Deserialize, Serialize};
+
+/// an ascending nonce as assigned per upload for the live channel.
+pub type UploadId = u64;
+
+pub type ValidateResponse = CallResponse<serde_json::Value>;
+
+/// A type mapping fragment indices (as represented by u64's) to
+/// Some type
+pub type IdMap<T> = HashMap<u64, T>;
+
+/// Generic call wrapper
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum CallResponse<T> {
+    Error { error: T },
+    Diff { diff: T },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ValidateUpload {
+    #[serde(flatten)]
+    id_map: HashMap<UploadId, IdMap<IdMap<String>>>,
+}

--- a/crates/core/src/live_socket/socket.rs
+++ b/crates/core/src/live_socket/socket.rs
@@ -4,7 +4,7 @@ use log::debug;
 use phoenix_channels_client::{url::Url, Number, Payload, Socket, Topic, JSON};
 use reqwest::Method;
 
-use super::{form::FormModel, LiveChannel, LiveSocketError};
+use super::{form::Form, LiveChannel, LiveSocketError};
 use crate::{
     diff::fragment::{Root, RootDiff},
     dom::{ffi::Document as FFiDocument, AttributeName, Document, ElementName, Selector},
@@ -40,7 +40,6 @@ impl Default for ConnectOpts {
 
 #[derive(uniffi::Object)]
 pub struct LiveSocket {
-    pub forms: Vec<FormModel>,
     pub socket: Arc<Socket>,
     pub csrf_token: String,
     pub phx_id: String,
@@ -51,6 +50,7 @@ pub struct LiveSocket {
     pub dead_render: Document,
     pub style_urls: Vec<String>,
     pub has_live_reload: bool,
+    forms: Vec<Form>,
     cookies: Vec<String>,
     timeout: Duration,
 }

--- a/crates/core/src/live_socket/socket.rs
+++ b/crates/core/src/live_socket/socket.rs
@@ -324,6 +324,22 @@ impl LiveSocket {
         let join_payload = channel.join(self.timeout).await?;
         let document = Document::empty();
 
+        let file_upload_id = document
+            .select(Selector::Attribute(AttributeName {
+                namespace: None,
+                name: "data-phx-upload-ref".into(),
+            }))
+            .nth(0)
+            .map(|node_ref| document.get(node_ref))
+            .and_then(|input_div| {
+                input_div
+                    .attributes()
+                    .iter()
+                    .filter(|attr| attr.name.name == "id")
+                    .map(|attr| attr.value.clone())
+                    .collect::<Option<String>>()
+            });
+
         debug!("Join payload: {join_payload:#?}");
 
         Ok(LiveChannel {
@@ -332,6 +348,7 @@ impl LiveSocket {
             socket: self.socket.clone(),
             document: document.into(),
             timeout: self.timeout,
+            file_upload_id,
         })
     }
 
@@ -436,12 +453,29 @@ impl LiveSocket {
         }
         .ok_or(LiveSocketError::NoDocumentInJoinPayload)?;
 
+        let file_upload_id = document
+            .select(Selector::Attribute(AttributeName {
+                namespace: None,
+                name: "data-phx-upload-ref".into(),
+            }))
+            .nth(0)
+            .map(|node_ref| document.get(node_ref))
+            .and_then(|input_div| {
+                input_div
+                    .attributes()
+                    .iter()
+                    .filter(|attr| attr.name.name == "id")
+                    .map(|attr| attr.value.clone())
+                    .collect::<Option<String>>()
+            });
+
         Ok(LiveChannel {
             channel,
             join_payload,
             socket: self.socket.clone(),
             document: document.into(),
             timeout: self.timeout,
+            file_upload_id,
         })
     }
 

--- a/crates/core/src/live_socket/tests/mod.rs
+++ b/crates/core/src/live_socket/tests/mod.rs
@@ -43,7 +43,6 @@ async fn join_live_view() {
     </Text>
 </VStack>"#;
     assert_eq!(expected, rendered);
-    let _phx_input_id = live_channel.get_phx_ref_from_upload_join_payload();
 
     let _live_channel = live_socket
         .join_livereload_channel()

--- a/crates/core/src/live_socket/tests/mod.rs
+++ b/crates/core/src/live_socket/tests/mod.rs
@@ -32,6 +32,7 @@ async fn join_live_view() {
         .join_liveview_channel(None, None)
         .await
         .expect("Failed to join channel");
+
     let join_doc = live_channel
         .join_document()
         .expect("Failed to render join payload");

--- a/crates/core/src/live_socket/tests/upload.rs
+++ b/crates/core/src/live_socket/tests/upload.rs
@@ -83,8 +83,8 @@ async fn multi_chunk_file() {
     let me = live_channel
         .construct_upload(
             image_bytes.clone(),
-            "image/tiff".to_string(),
-            "tile.tiff".to_string(),
+            "image/png".to_string(),
+            "tile.png".to_string(),
             "avatar".to_string(),
         )
         .expect("Could not construct file.");
@@ -125,8 +125,8 @@ async fn error_file_too_large() {
     let me = live_channel
         .construct_upload(
             image_bytes.clone(),
-            "image/tiff".to_string(),
-            "tile.tiff".to_string(),
+            "image/png".to_string(),
+            "tile.png".to_string(),
             "avatar".to_string(),
         )
         .expect("Could not construct file.");
@@ -135,18 +135,19 @@ async fn error_file_too_large() {
         .validate_upload(&me)
         .await
         .expect("Failed to validate upload");
+
     let out = live_channel
         .upload_file(&me)
         .await
         .expect_err("This file is too big and should have failed");
 
-    // This hack is required because LiveSocketError doesn't derive from PartialEq
-    if let LiveSocketError::Upload {
-        error: UploadError::FileTooLarge,
-    } = out
-    {
-    } else {
-        panic!("This should be a FileTooLarge Error");
+    match out {
+        LiveSocketError::Upload {
+            error: UploadError::FileTooLarge,
+        } => {}
+        e => {
+            panic!("This should be a FileTooLarge, Error instead was: {e:?}");
+        }
     }
 }
 

--- a/crates/core/src/live_socket/tests/upload.rs
+++ b/crates/core/src/live_socket/tests/upload.rs
@@ -62,6 +62,45 @@ async fn single_chunk_file() {
 }
 
 #[tokio::test]
+async fn multi_chunk_text() {
+    let _ = env_logger::builder()
+        .parse_default_env()
+        .is_test(true)
+        .try_init();
+
+    let url = format!("http://{HOST}/upload");
+    let text_bytes = Vec::from_iter(std::iter::repeat_n(b'a', 48_000));
+
+    let live_socket = LiveSocket::new(url.to_string(), "swiftui".into(), Default::default())
+        .await
+        .expect("Failed to get liveview socket");
+
+    let live_channel = live_socket
+        .join_liveview_channel(None, None)
+        .await
+        .expect("Failed to join the liveview channel");
+
+    let me = live_channel
+        .construct_upload(
+            text_bytes.clone(),
+            "text/plain".to_string(),
+            "lots_of_as.txt".to_string(),
+            "sample_text".to_string(),
+        )
+        .expect("Could not construct file.");
+
+    let _ = live_channel
+        .validate_upload(&me)
+        .await
+        .expect("Failed to validate upload");
+
+    live_channel
+        .upload_file(&me)
+        .await
+        .expect("Failed to upload");
+}
+
+#[tokio::test]
 async fn multi_chunk_file() {
     let _ = env_logger::builder()
         .parse_default_env()

--- a/crates/core/src/live_socket/tests/upload.rs
+++ b/crates/core/src/live_socket/tests/upload.rs
@@ -41,16 +41,20 @@ async fn single_chunk_file() {
         .await
         .expect("Failed to join the liveview channel");
 
-    let gh_favicon = LiveFile::new(
-        image_bytes.clone(),
-        "image/png".to_string(),
-        "tile.png".to_string(),
-        "avatar".to_string(),
-    );
+    let gh_favicon = live_channel
+        .construct_upload(
+            image_bytes.clone(),
+            "image/png".to_string(),
+            "tile.png".to_string(),
+            "avatar".to_string(),
+        )
+        .expect("Could not construct file.");
+
     let _ = live_channel
         .validate_upload(&gh_favicon)
         .await
         .expect("Failed to validate upload");
+
     live_channel
         .upload_file(&gh_favicon)
         .await
@@ -70,21 +74,26 @@ async fn multi_chunk_file() {
     let live_socket = LiveSocket::new(url.to_string(), "swiftui".into(), Default::default())
         .await
         .expect("Failed to get liveview socket");
+
     let live_channel = live_socket
         .join_liveview_channel(None, None)
         .await
         .expect("Failed to join the liveview channel");
 
-    let me = LiveFile::new(
-        image_bytes.clone(),
-        "image/png".to_string(),
-        "tile.png".to_string(),
-        "avatar".to_string(),
-    );
+    let me = live_channel
+        .construct_upload(
+            image_bytes.clone(),
+            "image/tiff".to_string(),
+            "tile.tiff".to_string(),
+            "avatar".to_string(),
+        )
+        .expect("Could not construct file.");
+
     let _ = live_channel
         .validate_upload(&me)
         .await
         .expect("Failed to validate upload");
+
     live_channel
         .upload_file(&me)
         .await
@@ -113,12 +122,15 @@ async fn error_file_too_large() {
         .await
         .expect("Failed to join the liveview channel");
 
-    let me = LiveFile::new(
-        image_bytes.clone(),
-        "image/png".to_string(),
-        "tile.png".to_string(),
-        "avatar".to_string(),
-    );
+    let me = live_channel
+        .construct_upload(
+            image_bytes.clone(),
+            "image/tiff".to_string(),
+            "tile.tiff".to_string(),
+            "avatar".to_string(),
+        )
+        .expect("Could not construct file.");
+
     let _ = live_channel
         .validate_upload(&me)
         .await
@@ -159,12 +171,15 @@ async fn error_incorrect_file_type() {
         .await
         .expect("Failed to join the liveview channel");
 
-    let me = LiveFile::new(
-        image_bytes.clone(),
-        "image/tiff".to_string(),
-        "tile.tiff".to_string(),
-        "avatar".to_string(),
-    );
+    let me = live_channel
+        .construct_upload(
+            image_bytes.clone(),
+            "image/tiff".to_string(),
+            "tile.tiff".to_string(),
+            "avatar".to_string(),
+        )
+        .expect("Could not construct file.");
+
     let _ = live_channel
         .validate_upload(&me)
         .await
@@ -172,7 +187,7 @@ async fn error_incorrect_file_type() {
     let out = live_channel
         .upload_file(&me)
         .await
-        .expect_err("This should b ean incorrect file error");
+        .expect_err("This should be an incorrect file error");
     // This hack is required because LiveSocketError doesn't derive from PartialEq
     if let LiveSocketError::Upload {
         error: UploadError::FileNotAccepted,

--- a/crates/core/src/live_socket/tests/upload.rs
+++ b/crates/core/src/live_socket/tests/upload.rs
@@ -31,22 +31,21 @@ async fn single_chunk_file() {
 
     let url = format!("http://{HOST}/upload");
     let image_bytes = get_image(100, 100, "png".to_string());
+
     let live_socket = LiveSocket::new(url.to_string(), "swiftui".into(), Default::default())
         .await
         .expect("Failed to get liveview socket");
+
     let live_channel = live_socket
         .join_liveview_channel(None, None)
         .await
         .expect("Failed to join the liveview channel");
-    let phx_input_id = live_channel
-        .get_phx_ref_from_upload_join_payload()
-        .expect("Failed to get phx id from join payload");
 
     let gh_favicon = LiveFile::new(
         image_bytes.clone(),
-        "png".to_string(),
+        "image/png".to_string(),
         "tile.png".to_string(),
-        phx_input_id.clone(),
+        "avatar".to_string(),
     );
     let _ = live_channel
         .validate_upload(&gh_favicon)
@@ -75,15 +74,12 @@ async fn multi_chunk_file() {
         .join_liveview_channel(None, None)
         .await
         .expect("Failed to join the liveview channel");
-    let phx_input_id = live_channel
-        .get_phx_ref_from_upload_join_payload()
-        .expect("Failed to get phx id from join payload");
 
     let me = LiveFile::new(
         image_bytes.clone(),
-        "png".to_string(),
+        "image/png".to_string(),
         "tile.png".to_string(),
-        phx_input_id,
+        "avatar".to_string(),
     );
     let _ = live_channel
         .validate_upload(&me)
@@ -111,19 +107,17 @@ async fn error_file_too_large() {
     let live_socket = LiveSocket::new(url.to_string(), "swiftui".into(), Default::default())
         .await
         .expect("Failed to get liveview socket");
+
     let live_channel = live_socket
         .join_liveview_channel(None, None)
         .await
         .expect("Failed to join the liveview channel");
-    let phx_input_id = live_channel
-        .get_phx_ref_from_upload_join_payload()
-        .expect("Failed to get phx id from join payload");
 
     let me = LiveFile::new(
         image_bytes.clone(),
-        "png".to_string(),
+        "image/png".to_string(),
         "tile.png".to_string(),
-        phx_input_id,
+        "avatar".to_string(),
     );
     let _ = live_channel
         .validate_upload(&me)
@@ -164,15 +158,12 @@ async fn error_incorrect_file_type() {
         .join_liveview_channel(None, None)
         .await
         .expect("Failed to join the liveview channel");
-    let phx_input_id = live_channel
-        .get_phx_ref_from_upload_join_payload()
-        .expect("Failed to get phx id from join payload");
 
     let me = LiveFile::new(
         image_bytes.clone(),
-        "tiff".to_string(),
+        "image/tiff".to_string(),
         "tile.tiff".to_string(),
-        phx_input_id,
+        "avatar".to_string(),
     );
     let _ = live_channel
         .validate_upload(&me)

--- a/tests/support/test_server/lib/test_server_web/live/upload_live.ex
+++ b/tests/support/test_server/lib/test_server_web/live/upload_live.ex
@@ -5,9 +5,9 @@ defmodule TestServerWeb.SimpleLiveUpload do
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     {:ok,
-      socket
-      |> assign(:uploaded_files, [])
-      |> allow_upload(:avatar, accept: ~w(.png), max_entries: 2)}
+     socket
+     |> assign(:uploaded_files, [])
+     |> allow_upload(:avatar, accept: ~w(.png), max_entries: 2)}
   end
 
   @impl true
@@ -40,7 +40,7 @@ defmodule TestServerWeb.SimpleLiveUpload do
       consume_uploaded_entries(socket, :avatar, fn %{path: path}, _entry ->
         dest = Path.join([:code.priv_dir(:test_server), "static", "uploads", Path.basename(path)])
         dest = "#{dest}.png"
-        IO.puts ("HANDLING SAVE EVENT: #{path} - #{dest}")
+        IO.puts("HANDLING SAVE EVENT: #{path} - #{dest}")
         File.cp!(path, dest)
         {:ok, ~p"/uploads/#{Path.basename(dest)}"}
       end)

--- a/tests/support/test_server/lib/test_server_web/live/upload_live.ex
+++ b/tests/support/test_server/lib/test_server_web/live/upload_live.ex
@@ -7,7 +7,8 @@ defmodule TestServerWeb.SimpleLiveUpload do
     {:ok,
      socket
      |> assign(:uploaded_files, [])
-     |> allow_upload(:avatar, accept: ~w(.png), max_entries: 2)}
+     |> allow_upload(:avatar, accept: ~w(.png), max_entries: 2)
+     |> allow_upload(:sample_text, accept: ~w(.txt))}
   end
 
   @impl true
@@ -18,6 +19,7 @@ defmodule TestServerWeb.SimpleLiveUpload do
     <form id="upload-form" phx-submit="save" phx-change="validate">
 
       <.live_file_input upload={@uploads.avatar} />
+      <.live_file_input upload={@uploads.sample_text} />
 
       <button type="submit">Upload</button>
     </form>
@@ -25,7 +27,8 @@ defmodule TestServerWeb.SimpleLiveUpload do
   end
 
   @impl true
-  def handle_event("validate", _params, socket) do
+  def handle_event("validate", params, socket) do
+    IO.puts("VALIDATION REQUEST: #{inspect(params)}")
     {:noreply, socket}
   end
 
@@ -35,15 +38,31 @@ defmodule TestServerWeb.SimpleLiveUpload do
   end
 
   @impl true
-  def handle_event("save", _params, socket) do
+  def handle_event("save", _, socket) do
     uploaded_files =
-      consume_uploaded_entries(socket, :avatar, fn %{path: path}, _entry ->
+      consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
         dest = Path.join([:code.priv_dir(:test_server), "static", "uploads", Path.basename(path)])
         dest = "#{dest}.png"
+
         IO.puts("HANDLING SAVE EVENT: #{path} - #{dest}")
         File.cp!(path, dest)
         {:ok, ~p"/uploads/#{Path.basename(dest)}"}
       end)
+
+    # This is not idiomatic but I want to cut down on boiler plate
+    # we need to add a way to inject upload params to the client
+    upload_files =
+      uploaded_files ++
+        consume_uploaded_entries(socket, :sample_text, fn %{path: path}, entry ->
+          dest =
+            Path.join([:code.priv_dir(:test_server), "static", "uploads", Path.basename(path)])
+
+          dest = "#{dest}.txt"
+
+          IO.puts("HANDLING SAVE EVENT: #{path} - #{dest}")
+          File.cp!(path, dest)
+          {:ok, ~p"/uploads/#{Path.basename(dest)}"}
+        end)
 
     {:noreply, update(socket, :uploaded_files, &(&1 ++ uploaded_files))}
   end
@@ -60,6 +79,7 @@ defmodule TestServerWeb.SimpleLiveUpload.SwiftUI do
     ~LVN"""
     <UploadForm>
       <Phoenix.Component.live_file_input upload={@uploads.avatar} />
+      <Phoenix.Component.live_file_input upload={@uploads.sample_text} />
     </UploadForm>
     """
   end
@@ -73,6 +93,7 @@ defmodule TestServerWeb.SimpleLiveUpload.Jetpack do
     <Box size="fill" background="system-blue">
       <Text align="Center">Upload from Jetpack</Text>
       <Phoenix.Component.live_file_input upload={@uploads.avatar} />
+      <Phoenix.Component.live_file_input upload={@uploads.sample_text} />
     </Box>
     """
   end


### PR DESCRIPTION
- ref id's were hardcoded
- consolidate phx upload id to channel dependant constructor, wrote extractor for getting them 
- upload target names were hardcoded

TODO:
- [ ] consolidate `call` error handling.
- [ ]  finish transferring steps into protocol module.
- [x]  multiple file upload tests.
- [ ]  ensure diffs are applied as upload messages come in. 
- [ ]  Write a way to instrument chunk upload timeouts outside of the channel timeout.
- [ ]  Check mime type